### PR TITLE
Added developersIndia logo as a site favicon

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Saadhan by r/developersIndia</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" />
+  <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/developersIndia/assets/main/favicons/favicon.ico">
   <style>
     a {
       color: #E4376D;


### PR DESCRIPTION
## Description

Solving issue #8 "Add developersIndia logo as a site favicon"
Used "<https://raw.githubusercontent.com/developersIndia/assets/main/favicons/favicon.ico>" as the favicon.