### PR TITLE
Add flask-wtf

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,44 @@
+import os
+from pathlib import Path
 from flask import Flask, request, render_template
+from flask_wtf import FlaskForm
+from wtforms.fields import SelectField
+from dotenv import load_dotenv
 from resourcer import resourcer
 
+BASE_DIR = Path(__file__).resolve().parent
+
+load_dotenv(BASE_DIR / ".env")
+
+
+class Config:
+    SECRET_KEY = os.getenv("SECRET_KEY") or "SECRET_KEY"
+
+
+class FilterLevelForm(FlaskForm):
+    level = SelectField("level", choices=[
+        ("beginner", "beginner"),
+        ("intermediate", "intermediate"),
+        ("advanced", "advanced"),
+        ("everyone", "everyone"),
+    ])
+
+
+class FilterTypeForm(FlaskForm):
+    type = SelectField("type", choices=[
+        ("video", "video"),
+        ("article", "article"),
+        ("book", "book"),
+        ("github", "github"),
+        ("course", "course"),
+        ("audio", "audio"),
+        ("cheatsheet", "cheatsheet"),
+        ("website", "website"),
+    ])
+
+
 app = Flask(__name__)
+app.config.from_object(Config)
 
 CATEGORIES = {
     "Python": "python",
@@ -30,8 +67,10 @@ def category():
     category = request.args.get("category")
     rsr = resourcer.Resource(category)
     resources = rsr.get_resource()
+    level_form = FilterLevelForm()
+    type_form = FilterTypeForm()
     return render_template(
-        "resources.html", resources=resources["resources"], category=category
+        "resources.html", resources=resources["resources"], category=category, level_form=level_form, type_form=type_form
     )
 
 
@@ -45,20 +84,21 @@ def contributors():
 
 @app.route("/filtered_resources", methods=["POST"])
 def filtered_resources():
-    res_type = request.form.get("type")
-    res_level = request.form.get("level")
-
     rsr = resourcer.Resource(request.form.get("category"))
-
-    if res_level is not None:
+    level_form = FilterLevelForm()
+    if level_form.validate_on_submit():
+        res_level = level_form.level.data
         resources = rsr.get_resources_by_level(res_level)
         return render_template("filtered_resources.html", resources=resources)
 
-    elif res_type is not None:
+    type_form = FilterTypeForm()
+    if type_form.validate_on_submit():
+        res_type = type_form.type.data
         resources = rsr.get_resources_by_type(res_type)
         return render_template("filtered_resources.html", resources=resources)
 
     return "Wuba luba dub dub"
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 exceptiongroup==1.0.4
 Flask==2.2.2
+Flask-WTF==1.1.1
 idna==3.4
 importlib-metadata==5.0.0
 itsdangerous==2.1.2
@@ -15,12 +16,14 @@ MarkupSafe==2.1.1
 mypy-extensions==0.4.3
 pathspec==0.10.2
 platformdirs==2.5.4
+python-dotenv==0.21.1
 requests==2.28.1
 requests-cache==0.9.7
 six==1.16.0
 tomli==2.0.1
-typing-extensions==4.4.0
+typing_extensions==4.4.0
 url-normalize==1.4.3
 urllib3==1.26.12
 Werkzeug==2.2.2
+WTForms==3.0.1
 zipp==3.10.0

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -11,13 +11,8 @@
             <div class="control">
                 <div class="select">
                     <form action="">
-                        <select name="level" hx-vals='{"category":"{{category}}"}' hx-post="/filtered_resources"
-                            hx-target="#resources">
-                            <option value="beginner">beginner</option>
-                            <option value="intermediate">intermediate</option>
-                            <option value="advanced">advanced</option>
-                            <option value="everyone">everyone</option>
-                        </select>
+                        {{ level_form.hidden_tag() }}
+                        {{ level_form.level(**{'hx-vals': '{"category":"%s"}'|format(category), 'hx-post': url_for('filtered_resources'), 'hx-target': '#resources'}) }}
                     </form>
                 </div>
             </div>
@@ -27,16 +22,10 @@
             <p class="subtitle is-4">Filter by type</p>
             <div class="control">
                 <div class="select">
-                    <select name="type" hx-post="/filtered_resources" hx-vals='{"category":"{{category}}"}' hx-target="#resources">
-                        <option value="video">video</option>
-                        <option value="article">article</option>
-                        <option value="book">book </option>
-                        <option value="github">github</option>
-                        <option value="course">course</option>
-                        <option value="audio">audio</option>
-                        <option value="cheatsheet">cheatsheet</option>
-                        <option value="website">website</option>
-                    </select>
+                    <form action="">
+                        {{ type_form.hidden_tag() }}
+                        {{ type_form.type(**{'hx-vals': '{"category":"%s"}'|format(category), 'hx-post': url_for('filtered_resources'), 'hx-target': '#resources'}) }}
+                    </form>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Use flask-wtf in place of HTML forms

Using flask-wtf in place of HTML forms reduces HTML boilerplate and also provides CSRF protection.

Fixes #32 

## Changes Include
- Adding flask-wtf, python-dotenv
- Updating resources.html
- Updating main.py to generate wtforms and check for CSRF tokens

- [X] New feature ✨ (non-breaking change which adds functionality)
- [X] Refactor ⚒️ (code change that neither fixes a bug nor adds a feature)

## How Has This Been Tested?

- [X] Postman / Chrome 109

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
