### PR TITLE
Add exception/error handling page

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,6 +159,9 @@ def filtered_resources():
 
     return "Wuba luba dub dub"
 
+@app.errorhandler(Exception)
+def handle_exception(e):
+    return render_template("error.html", endpoint=None)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ title }}">
-  <meta property="og:url" content="{{ url_for(request.endpoint, _external=True) }}" />
+  <meta property="og:url" content="{{ request.url }}" />
 	<meta name="twitter:site" content="@devsinindia">
 	<meta name="twitter:creator" content="@devsinindia">
 	<meta property="og:site_name" content="Saadhan - A resource hub by r/developersIndia">
@@ -19,7 +19,7 @@
 
   <title>{{ title }}</title>
 
-  <link rel="canonical" href="{{ url_for(request.endpoint, _external=True) }}">
+  <link rel="canonical" href="{{ request.url }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" />
   <link rel="icon" type="image/x-icon"
     href="https://raw.githubusercontent.com/developersIndia/assets/main/logo.svg">

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="has-text-centered notification is-danger mx-3">
+  <h2 class="title is-3">Something Went Wrong!</h2>
+
+  Return to <a href="/">Home</a>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
## Description

On an error/expection, It will now show `error.html` page instead of throwing flask default debug page.

Fixes #38 

## Changes Include

- [x] Bug fix 🐛 (non-breaking change which fixes an issue)
- [x] New feature ✨ (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if any)
![image](https://github.com/user-attachments/assets/a24452db-d9b0-4a52-bcfd-6f6d4fbc02d0)
